### PR TITLE
Add bi4busobj RDS Resources for Staging

### DIFF
--- a/groups/rds/data.tf
+++ b/groups/rds/data.tf
@@ -19,6 +19,13 @@ data "aws_security_group" "rds_shared" {
   }
 }
 
+data "aws_security_group" "busobj_app" {
+  filter {
+    name   = "group-name"
+    values = ["sgr-windows-workloads-bus-obj-*"]
+  }
+}
+
 data "aws_route53_zone" "private_zone" {
   name         = local.internal_fqdn
   private_zone = true

--- a/groups/rds/data.tf
+++ b/groups/rds/data.tf
@@ -40,6 +40,10 @@ data "vault_generic_secret" "bi4cms_rds" {
   path = "applications/${var.aws_profile}/bi4cms/rds"
 }
 
+data "vault_generic_secret" "busobj_rds" {
+  path = "applications/${var.aws_profile}/bi4busobj/rds"
+}
+
 data "vault_generic_secret" "internal_cidrs" {
   path = "aws-accounts/network/internal_cidr_ranges"
 }

--- a/groups/rds/locals.tf
+++ b/groups/rds/locals.tf
@@ -12,10 +12,34 @@ locals {
   busobj_rds_data = data.vault_generic_secret.busobj_rds.data
 
   rds_ingress_from_services = {
-    "bi4aud" = []
-    "bi4cms" = []
+    "bi4aud" = [
+      {
+        from_port                = 1521
+        to_port                  = 1521
+        protocol                 = "tcp"
+        description              = "Business Objects Application Access"
+        source_security_group_id = data.aws_security_group.busobj_app.id
+      }
+    ],
+    "bi4cms" = [
+      {
+        from_port                = 1521
+        to_port                  = 1521
+        protocol                 = "tcp"
+        description              = "Business Objects Application Access"
+        source_security_group_id = data.aws_security_group.busobj_app.id
+      }
+    ]
   }
-  busobj_rds_ingress_from_services = []
+  busobj_rds_ingress_from_services = [
+      {
+        from_port                = 1521
+        to_port                  = 1521
+        protocol                 = "tcp"
+        description              = "Business Objects Application Access"
+        source_security_group_id = data.aws_security_group.busobj_app.id
+      }
+  ]
 
   default_tags = {
     Terraform = "true"

--- a/groups/rds/locals.tf
+++ b/groups/rds/locals.tf
@@ -9,11 +9,13 @@ locals {
     bi4aud = data.vault_generic_secret.bi4aud_rds.data
     bi4cms = data.vault_generic_secret.bi4cms_rds.data
   }
+  busobj_rds_data = data.vault_generic_secret.busobj_rds.data
 
   rds_ingress_from_services = {
     "bi4aud" = []
     "bi4cms" = []
   }
+  busobj_rds_ingress_from_services = []
 
   default_tags = {
     Terraform = "true"

--- a/groups/rds/outputs.tf
+++ b/groups/rds/outputs.tf
@@ -3,3 +3,7 @@ output "rds_addresses" {
     dns.name => dns.fqdn
   }
 }
+
+output "busobj_rds_address" {
+  value = aws_route53_record.busobj_rds.fqdn
+}

--- a/groups/rds/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-staging-eu-west-2/vars
@@ -74,6 +74,32 @@ rds_databases = {
   }
 }
 
+# RDS Instance settings
+character_set_name           = "AL32UTF8"
+identifier                   = "bi4busobj"
+name                         = "bi4busobj"
+instance_class               = "db.m5.xlarge"
+allocated_storage            = 20
+backup_retention_period      = 2
+multi_az                     = false
+rds_maintenance_window       = "Wed:00:00-Wed:03:00"
+rds_backup_window            = "03:00-06:00"
+performance_insights_enabled = false
+
+# RDS Engine settings
+major_engine_version       = "12.1"
+engine_version             = "12.1.0.2.v25"
+license_model              = "license-included"
+auto_minor_version_upgrade = true
+
+# RDS logging
+rds_log_exports = [
+  "alert",
+  "audit",
+  "listener",
+  "trace"
+]
+
 # RDS Param and Option settings
 parameter_group_settings = [
   {

--- a/groups/rds/rds.tf
+++ b/groups/rds/rds.tf
@@ -27,6 +27,31 @@ module "rds_security_group" {
   egress_rules = ["all-all"]
 }
 
+module "busobj_rds_security_group" {
+
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 3.0"
+
+  name        = "sgr-${var.identifier}-rds-001"
+  description = "Security group for the ${var.identifier} RDS database"
+  vpc_id      = data.aws_vpc.vpc.id
+
+  ingress_cidr_blocks = local.admin_cidrs
+  ingress_rules       = ["oracle-db-tcp"]
+  ingress_with_cidr_blocks = [
+    {
+      from_port   = 5500
+      to_port     = 5500
+      protocol    = "tcp"
+      description = "Oracle Enterprise Manager"
+      cidr_blocks = join(",", local.admin_cidrs)
+    }
+  ]
+  ingress_with_source_security_group_id = []
+
+  egress_rules = ["all-all"]
+}
+
 # ------------------------------------------------------------------------------
 # RDS Instance
 # ------------------------------------------------------------------------------
@@ -120,6 +145,107 @@ module "rds" {
     local.default_tags,
     map(
       "ServiceTeam", format("%s-DBA-Support", upper(each.key))
+    )
+  )
+}
+
+module "busobj_rds" {
+  source  = "terraform-aws-modules/rds/aws"
+  version = "2.23.0"
+
+  create_db_parameter_group = true
+  create_db_subnet_group    = true
+
+  character_set_name         = var.character_set_name
+  identifier                 = "rds-${var.identifier}-${var.environment}-001"
+  engine                     = "oracle-se2"
+  major_engine_version       = var.major_engine_version
+  engine_version             = var.engine_version
+  auto_minor_version_upgrade = var.auto_minor_version_upgrade
+  license_model              = var.license_model
+  instance_class             = var.instance_class
+  allocated_storage          = var.allocated_storage
+  storage_type               = var.storage_type
+  iops                       = var.iops
+  multi_az                   = var.multi_az
+  storage_encrypted          = true
+  kms_key_id                 = data.aws_kms_key.rds.arn
+
+  name     = upper(var.name)
+  username = local.busobj_rds_data["admin-username"]
+  password = local.busobj_rds_data["admin-password"]
+  port     = "1521"
+
+  deletion_protection       = true
+  maintenance_window        = var.rds_maintenance_window
+  backup_window             = var.rds_backup_window
+  backup_retention_period   = var.backup_retention_period
+  skip_final_snapshot       = false
+  final_snapshot_identifier = "${var.identifier}-final-deletion-snapshot"
+
+  # Enhanced Monitoring
+  monitoring_interval             = "30"
+  monitoring_role_arn             = data.aws_iam_role.rds_enhanced_monitoring.arn
+  enabled_cloudwatch_logs_exports = var.rds_log_exports
+
+  performance_insights_enabled          = var.performance_insights_enabled
+  performance_insights_kms_key_id       = data.aws_kms_key.rds.arn
+  performance_insights_retention_period = 7
+
+  # RDS Security Group
+  vpc_security_group_ids = [
+    module.busobj_rds_security_group.this_security_group_id,
+    data.aws_security_group.rds_shared.id
+  ]
+
+  # DB subnet group
+  subnet_ids = data.aws_subnet_ids.data.ids
+
+  # DB Parameter group
+  family = "oracle-se2-${var.major_engine_version}"
+
+  parameters = var.parameter_group_settings
+
+  options = [
+    {
+      option_name                    = "OEM"
+      port                           = "5500"
+      vpc_security_group_memberships = [module.busobj_rds_security_group.this_security_group_id]
+    },
+    {
+      option_name = "JVM"
+    },
+    {
+      option_name = "SQLT"
+      version     = "2018-07-25.v1"
+      option_settings = [
+        {
+          name  = "LICENSE_PACK"
+          value = "N"
+        },
+      ]
+    },
+    {
+      option_name = "Timezone"
+      option_settings = [
+        {
+          name  = "TIME_ZONE"
+          value = "Europe/London"
+        },
+      ]
+    }
+  ]
+
+  timeouts = {
+    "create" : "80m",
+    "delete" : "80m",
+    "update" : "80m"
+  }
+
+  tags = merge(
+    local.default_tags,
+    map(
+      "ServiceTeam", "${upper(var.identifier)}-DBA-Support"
     )
   )
 }

--- a/groups/rds/rds.tf
+++ b/groups/rds/rds.tf
@@ -47,7 +47,7 @@ module "busobj_rds_security_group" {
       cidr_blocks = join(",", local.admin_cidrs)
     }
   ]
-  ingress_with_source_security_group_id = []
+  ingress_with_source_security_group_id = local.busobj_rds_ingress_from_services
 
   egress_rules = ["all-all"]
 }

--- a/groups/rds/route53.tf
+++ b/groups/rds/route53.tf
@@ -7,3 +7,11 @@ resource "aws_route53_record" "rds" {
   ttl     = "300"
   records = [module.rds[each.key].this_db_instance_address]
 }
+
+resource "aws_route53_record" "busobj_rds" {
+  zone_id = data.aws_route53_zone.private_zone.zone_id
+  name    = "${var.name}db"
+  type    = "CNAME"
+  ttl     = "300"
+  records = [module.busobj_rds.this_db_instance_address]
+}

--- a/groups/rds/variables.tf
+++ b/groups/rds/variables.tf
@@ -45,7 +45,117 @@ variable "rds_databases" {
   type = map
 }
 
+variable "character_set_name" {
+  type        = string
+  description = "Default character set for the database"
+  default     = "AL32UTF8"
+}
+
+variable "identifier" {
+  type        = string
+  description = "Name to give to the instances and other components created for it, will be added to naming structure e.g. mydb will become rds-mydb-<env>-001"
+}
+
+variable "name" {
+  type        = string
+  description = "Name to give to the database created on the RDS Instance"
+}
+
+variable "multi_az" {
+  type        = bool
+  description = "(Optional) Boolean to enable multi-az feature of RDS, subnets supplied must span multiple zones"
+  default     = false
+}
+
+variable "instance_class" {
+  type        = string
+  description = "The type of instance for the RDS"
+  default     = "db.t3.medium"
+}
+
+variable "rds_log_exports" {
+  type        = list(string)
+  description = "A list log types to export from RDS to Cloudwatch"
+  default     = []
+}
+
 variable "parameter_group_settings" {
   type        = list(any)
   description = "A list of parameters that will be set in the RDS instance parameter group"
+}
+
+variable "rds_onpremise_access" {
+  type        = list(string)
+  description = "A list of CIDR ranges or IPs to allow access from"
+  default     = []
+}
+
+variable "performance_insights_enabled" {
+  type        = bool
+  description = "Whether performance insights are required (true) or not (false). Typically enabled for Live resources."
+}
+
+# ------------------------------------------------------------------------------
+# RDS Storage Variables
+# ------------------------------------------------------------------------------
+variable "storage_type" {
+  type        = string
+  description = "One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'gp2' if not."
+  default     = null
+}
+
+variable "allocated_storage" {
+  type        = number
+  description = "The amount of storage in GB to launch RDS with"
+}
+
+variable "iops" {
+  type        = number
+  description = "Total number of IOPS to provision, requires storage type to be set to io1, there is a minimum of 1000 IOPS and 100GB storage required for Provisioned IOPS"
+  default     = null
+}
+
+# ------------------------------------------------------------------------------
+# RDS Maintenance Variables
+# ------------------------------------------------------------------------------
+variable "rds_maintenance_window" {
+  type        = string
+  description = "A maintenance window that will allow AWS to run maintenance on underlying hosts e.g. `Mon:00:00-Mon:03:00`"
+  default     = "Sat:00:00-Sat:03:00"
+}
+
+variable "rds_backup_window" {
+  type        = string
+  description = "A backup window that allows AWS to backup your RDS instance e.g. `03:00-06:00`"
+  default     = "03:00-06:00"
+}
+
+variable "backup_retention_period" {
+  type        = number
+  description = "The number of days to retain backups for - 0 to 35"
+  default     = 7
+}
+
+# ------------------------------------------------------------------------------
+# RDS Engine Type Variables
+# ------------------------------------------------------------------------------
+variable "major_engine_version" {
+  type        = string
+  description = "The major version of the database engine type e.g. 12.1"
+}
+
+variable "engine_version" {
+  type        = string
+  description = "The engine version provided by AWS RDS e.g. 12.1.0.2.v21"
+}
+
+variable "license_model" {
+  type        = string
+  description = "The license model for the engine, byol or license-include: https://aws.amazon.com/rds/oracle/faqs/"
+}
+
+variable "auto_minor_version_upgrade" {
+  type        = bool
+  description = "True/False value to allow AWS to apply minor version updates to RDS without approval from owner"
+  default     = true
 }


### PR DESCRIPTION
Added separate resources for new `bi4busobj` RDS instance.
* This instance will be used to consolidate and replace the existing `bi4aud` and `bi4cms` RDS instances and so has been added separately to allow for cleaner removal of existing resources once consolidation has been completed.

Added supporting variables for `bi4busobj` RDS resources

Resolves: CM-1115