### PR TITLE
Rename new Business Objects instance

### DIFF
--- a/groups/rds/data.tf
+++ b/groups/rds/data.tf
@@ -48,7 +48,7 @@ data "vault_generic_secret" "bi4cms_rds" {
 }
 
 data "vault_generic_secret" "busobj_rds" {
-  path = "applications/${var.aws_profile}/bi4busobj/rds"
+  path = "applications/${var.aws_profile}/bibusobj/rds"
 }
 
 data "vault_generic_secret" "internal_cidrs" {

--- a/groups/rds/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-staging-eu-west-2/vars
@@ -76,8 +76,8 @@ rds_databases = {
 
 # RDS Instance settings
 character_set_name           = "AL32UTF8"
-identifier                   = "bi4busobj"
-name                         = "bi4busobj"
+identifier                   = "bibusobj"
+name                         = "bibusobj"
 instance_class               = "db.m5.xlarge"
 allocated_storage            = 20
 backup_retention_period      = 2


### PR DESCRIPTION
Updated name of Business Objects instance from `bi4busobj` to `bibusobj` to fit within the DBName length constraints (8 characters)