### PR TITLE
Add RDS CloudWatch Alarms

### DIFF
--- a/groups/rds/profiles/heritage-live-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-live-eu-west-2/vars
@@ -110,3 +110,8 @@ parameter_group_settings = [
     value = "AUTO"
   },
 ]
+
+## CloudWatch Alarms
+alarm_actions_enabled  = false
+alarm_topic_name       = "Email_Alerts"
+alarm_topic_name_ooh   = "Phonecall_Alerts"

--- a/groups/rds/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-staging-eu-west-2/vars
@@ -114,3 +114,8 @@ parameter_group_settings = [
 rds_schedule_enable = true
 rds_start_schedule  = "cron(0 5 * * ? *)"
 rds_stop_schedule   = "cron(0 21 * * ? *)"
+
+## CloudWatch Alarms
+alarm_actions_enabled  = false
+alarm_topic_name       = ""
+alarm_topic_name_ooh   = ""

--- a/groups/rds/rds.tf
+++ b/groups/rds/rds.tf
@@ -139,3 +139,13 @@ module "rds_start_stop_schedule" {
   rds_start_schedule  = var.rds_start_schedule
   rds_stop_schedule   = var.rds_stop_schedule
 }
+
+module "rds_cloudwatch_alarms" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/rds_cloudwatch_alarms?ref=tags/1.0.167"
+
+  rds_instance_id        = module.busobj_rds.this_db_instance_id
+  rds_instance_shortname = upper(var.name)
+  alarm_actions_enabled  = var.alarm_actions_enabled
+  alarm_topic_name       = var.alarm_topic_name
+  alarm_topic_name_ooh   = var.alarm_topic_name_ooh
+}

--- a/groups/rds/variables.tf
+++ b/groups/rds/variables.tf
@@ -176,3 +176,21 @@ variable "rds_stop_schedule" {
   default     = ""
   description = "The SSM cron expression to define when the RDS instance should be stopped"
 }
+
+# ------------------------------------------------------------------------------
+# RDS CloudWatch Alarm Variables
+# ------------------------------------------------------------------------------
+variable "alarm_actions_enabled" {
+  type        = string
+  description = "Defines whether SNS-based alarm actions should be enabled (true) or not (false) for alarms"
+}
+
+variable "alarm_topic_name" {
+  type        = string
+  description = "The name of the SNS topic to use for in-hours alarm notifications and clear notifications"
+}
+
+variable "alarm_topic_name_ooh" {
+  type        = string
+  description = "The name of the SNS topic to use for OOH alarm notifications"
+}

--- a/groups/rds/variables.tf
+++ b/groups/rds/variables.tf
@@ -181,7 +181,7 @@ variable "rds_stop_schedule" {
 # RDS CloudWatch Alarm Variables
 # ------------------------------------------------------------------------------
 variable "alarm_actions_enabled" {
-  type        = string
+  type        = bool
   description = "Defines whether SNS-based alarm actions should be enabled (true) or not (false) for alarms"
 }
 


### PR DESCRIPTION
Added module and supporting config to deploy standard RDS CloudWatch alarms
`alarm_actions` currently disabled to prevent notification spam while alarms settle after creation