### PR TITLE
Per-profile RDS options, disable JVM in staging

### DIFF
--- a/groups/rds/profiles/heritage-live-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-live-eu-west-2/vars
@@ -111,6 +111,31 @@ parameter_group_settings = [
   },
 ]
 
+option_group_settings = [
+  {
+    option_name = "JVM"
+  },
+  {
+    option_name = "SQLT"
+    version     = "2018-07-25.v1"
+    option_settings = [
+      {
+        name  = "LICENSE_PACK"
+        value = "N"
+      },
+    ]
+  },
+  {
+    option_name = "Timezone"
+    option_settings = [
+      {
+        name  = "TIME_ZONE"
+        value = "Europe/London"
+      },
+    ]
+  }
+]
+
 ## CloudWatch Alarms
 alarm_actions_enabled  = true
 alarm_topic_name       = "Email_Alerts"

--- a/groups/rds/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-staging-eu-west-2/vars
@@ -24,7 +24,7 @@ performance_insights_enabled = false
 major_engine_version       = "19"
 engine_version             = "19"
 license_model              = "license-included"
-auto_minor_version_upgrade = true
+auto_minor_version_upgrade = false
 
 # RDS logging
 rds_log_exports = [
@@ -109,6 +109,28 @@ parameter_group_settings = [
     name  = "workarea_size_policy"
     value = "AUTO"
   },
+]
+
+option_group_settings = [
+  {
+    option_name = "SQLT"
+    version     = "2018-07-25.v1"
+    option_settings = [
+      {
+        name  = "LICENSE_PACK"
+        value = "N"
+      },
+    ]
+  },
+  {
+    option_name = "Timezone"
+    option_settings = [
+      {
+        name  = "TIME_ZONE"
+        value = "Europe/London"
+      },
+    ]
+  }
 ]
 
 rds_schedule_enable = true

--- a/groups/rds/rds.tf
+++ b/groups/rds/rds.tf
@@ -86,35 +86,13 @@ module "busobj_rds" {
 
   parameters = var.parameter_group_settings
 
-  options = [
+  options = concat([
     {
       option_name                    = "OEM"
       port                           = "5500"
       vpc_security_group_memberships = [module.busobj_rds_security_group.this_security_group_id]
-    },
-    {
-      option_name = "JVM"
-    },
-    {
-      option_name = "SQLT"
-      version     = "2018-07-25.v1"
-      option_settings = [
-        {
-          name  = "LICENSE_PACK"
-          value = "N"
-        },
-      ]
-    },
-    {
-      option_name = "Timezone"
-      option_settings = [
-        {
-          name  = "TIME_ZONE"
-          value = "Europe/London"
-        },
-      ]
     }
-  ]
+  ], var.option_group_settings)
 
   timeouts = {
     "create" : "80m",

--- a/groups/rds/variables.tf
+++ b/groups/rds/variables.tf
@@ -80,6 +80,11 @@ variable "parameter_group_settings" {
   description = "A list of parameters that will be set in the RDS instance parameter group"
 }
 
+variable "option_group_settings" {
+  type        = any
+  description = "A list of options that will be set in the RDS instance option group"
+}
+
 variable "rds_onpremise_access" {
   type        = list(string)
   description = "A list of CIDR ranges or IPs to allow access from"


### PR DESCRIPTION
Moved RDS options in to vars to allow for per-profile changes
Updated rds.tf to concatenate standard OEM option with profile options
Removed JVM option and disabeld minor version upgrades in Staging